### PR TITLE
fix/API-7/endpoint-signup

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -4,11 +4,12 @@ import {
   UnauthorizedException,
   BadRequestException,
 } from '@nestjs/common';
+import { plainToInstance } from 'class-transformer';
 import { UserService } from 'src/user/user.service';
 import { LoginDTO, LoginResponseDTO } from './dto/login.dto';
-import { UserSignUpResponseDTO } from './dto/sign-up.dto';
 import { UserDTO } from 'src/user/dto/user.dto';
 import { JwtService } from '@nestjs/jwt';
+import { User } from 'src/user/entities/user.entity';
 
 @Injectable()
 export class AuthService {
@@ -47,13 +48,6 @@ export class AuthService {
 
     const newUser = await this.userService.create(newUserData);
 
-    const userCreated: UserSignUpResponseDTO = {
-      firstName: newUser.firstName,
-      lastName: newUser.lastName,
-      email: newUser.email,
-      documentId: newUser.documentId,
-      phoneNumber: newUser.phoneNumber,
-    };
-    return userCreated;
+    return plainToInstance(User, newUser);
   }
 }

--- a/src/auth/dto/sign-up.dto.ts
+++ b/src/auth/dto/sign-up.dto.ts
@@ -1,6 +1,0 @@
-import { OmitType } from '@nestjs/swagger';
-import { UserDTO } from 'src/user/dto/user.dto';
-
-export class UserSignUpResponseDTO extends OmitType(UserDTO, [
-  'password',
-] as const) {}

--- a/src/user/entities/user.entity.ts
+++ b/src/user/entities/user.entity.ts
@@ -1,5 +1,6 @@
 import { BaseModel } from 'src/utils/entity';
 import { Entity, Column } from 'typeorm';
+import { Exclude } from 'class-transformer';
 
 export enum UserRole {
   ADMIN = 'admin',
@@ -16,6 +17,7 @@ export class User extends BaseModel {
   @Column({ type: 'character varying', name: 'last_name' })
   lastName: string;
 
+  @Exclude()
   @Column({ type: 'character varying' })
   password: string;
 


### PR DESCRIPTION
En este fix se ha optado por usar la  serialización en NestJS es una herramienta que nos permite controlar cómo se transforman los datos en las respuestas de la API. Al utilizar @Exclude(), podemos asegurar que la información sensible, como las contraseñas, no se envíe a los clientes.
![image](https://github.com/user-attachments/assets/e4ddd0b4-d2e4-437f-ac25-e42c4808bf13)

