### PR TITLE
Fix/api 24/adjust validations in user creation

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -43,6 +43,7 @@ export class AuthController {
     const otp = generateOTP(6);
     await this.userService.saveOTP(user, otp);
 
+    /*
     await this.emailService.sendEmailByTemaplte(
       'otp_verification',
       {
@@ -51,6 +52,7 @@ export class AuthController {
       },
       otp,
     );
+    */
     return user;
   }
 

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -43,7 +43,6 @@ export class AuthController {
     const otp = generateOTP(6);
     await this.userService.saveOTP(user, otp);
 
-    /*
     await this.emailService.sendEmailByTemaplte(
       'otp_verification',
       {
@@ -52,7 +51,7 @@ export class AuthController {
       },
       otp,
     );
-    */
+
     return user;
   }
 

--- a/src/user/dto/user.dto.ts
+++ b/src/user/dto/user.dto.ts
@@ -9,6 +9,7 @@ import {
   MinLength,
 } from 'class-validator';
 import { UserGender } from '../entities/profile.entity';
+import { IsOlderThan } from 'src/utils/is-older-than-validator';
 
 export class UserDTO {
   @ApiProperty({ description: 'The name of the user' })
@@ -49,6 +50,7 @@ export class UserDTO {
     { strict: true },
     { message: 'birthDate must be a valid date in YYYY-MM-DD format' },
   )
+  @IsOlderThan(14)
   birthDate: string;
 
   @ApiProperty({

--- a/src/user/dto/user.dto.ts
+++ b/src/user/dto/user.dto.ts
@@ -5,6 +5,7 @@ import {
   IsEmail,
   IsEnum,
   IsNotEmpty,
+  IsOptional,
   MinLength,
 } from 'class-validator';
 import { UserGender } from '../entities/profile.entity';
@@ -34,9 +35,9 @@ export class UserDTO {
   @IsNotEmpty()
   documentId: string;
 
-  @ApiProperty({ description: 'the phone number of the user' })
-  @IsNotEmpty()
-  phoneNumber: string;
+  @ApiProperty({ description: 'the phone number of the user', required: false })
+  @IsOptional()
+  phoneNumber?: string;
 
   @ApiProperty({ description: 'the birth date of the user' })
   @Transform(
@@ -50,8 +51,12 @@ export class UserDTO {
   )
   birthDate: string;
 
-  @ApiProperty({ description: 'the gender of the user' })
-  @IsNotEmpty()
+  @ApiProperty({
+    description: 'the gender of the user',
+    required: false,
+    enum: UserGender,
+  })
+  @IsOptional()
   @IsEnum(UserGender)
-  gender: UserGender;
+  gender?: UserGender;
 }

--- a/src/user/entities/profile.entity.ts
+++ b/src/user/entities/profile.entity.ts
@@ -19,6 +19,6 @@ export class Profile extends UUIDModel {
   @Column({ type: 'date', name: 'birth_date' })
   birthDate: Date;
 
-  @Column({ type: 'enum', enum: UserGender })
+  @Column({ type: 'enum', enum: UserGender, nullable: true })
   gender: UserGender;
 }

--- a/src/user/entities/user.entity.ts
+++ b/src/user/entities/user.entity.ts
@@ -28,7 +28,7 @@ export class User extends BaseModel {
   @Column({ type: 'character varying', name: 'document_id', unique: true })
   documentId: string;
 
-  @Column({ type: 'character varying', name: 'phone_number' })
+  @Column({ type: 'character varying', name: 'phone_number', nullable: true })
   phoneNumber: string;
 
   @Column({ type: 'boolean', default: false, name: 'is_validated' })

--- a/src/user/migrations/1742571732901-FixNullableColumns-migration-signup.ts
+++ b/src/user/migrations/1742571732901-FixNullableColumns-migration-signup.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class FixNullableColumnsMigrationSignup1742571732901
+  implements MigrationInterface
+{
+  name = 'FixNullableColumnsMigrationSignup1742571732901';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "user" ALTER COLUMN "phone_number" DROP NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "profile" ALTER COLUMN "gender" DROP NOT NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "profile" ALTER COLUMN "gender" SET NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user" ALTER COLUMN "phone_number" SET NOT NULL`,
+    );
+  }
+}

--- a/src/user/migrations/1742572793664-fixNullableColumns-signup-migration.ts
+++ b/src/user/migrations/1742572793664-fixNullableColumns-signup-migration.ts
@@ -1,9 +1,9 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class FixNullableColumnsMigrationSignup1742571732901
+export class FixNullableColumnsSignupMigration1742572793664
   implements MigrationInterface
 {
-  name = 'FixNullableColumnsMigrationSignup1742571732901';
+  name = 'FixNullableColumnsSignupMigration1742572793664';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -67,7 +67,9 @@ export class UserService {
     const user = await this.userRepository.save(newUser);
     const profile = new Profile();
     profile.user = user;
-    profile.gender = userData.gender;
+    if (userData.gender) {
+      profile.gender = userData.gender;
+    }
     profile.birthDate = new Date(userData.birthDate);
     await this.profileRepository.save(profile);
     return user;

--- a/src/utils/is-older-than-validator.ts
+++ b/src/utils/is-older-than-validator.ts
@@ -1,0 +1,36 @@
+import {
+  registerDecorator,
+  ValidationArguments,
+  ValidationOptions,
+} from 'class-validator';
+
+export function IsOlderThan(
+  age: number,
+  validationOptions?: ValidationOptions,
+) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      name: 'IsOlderThan',
+      target: object.constructor,
+      propertyName,
+      options: validationOptions,
+      constraints: [age],
+      validator: {
+        validate(value: string, args: ValidationArguments) {
+          const birthDate = new Date(value);
+          const today = new Date();
+          const ageLimit = (args.constraints as number[])[0];
+          const minAllowedDate = new Date(
+            today.getFullYear() - ageLimit,
+            today.getMonth(),
+            today.getDate(),
+          );
+          return birthDate <= minAllowedDate;
+        },
+        defaultMessage(args: ValidationArguments) {
+          return `You must be at least ${args.constraints[0]} years old to register.`;
+        },
+      },
+    });
+  };
+}


### PR DESCRIPTION
Ajustando ciertas validaciones en el sign-up (creación de usuario) 
1) La longitud mínima del campo password debe ser 8 caracteres. (Se logro usando un decorador de NestJS).
2) La edad minima del usuario debe ser de 14 años. (Se logro con un decorador personalizado, el cual se puede utilizar para cualquier función de mayor que a nivel de fechas, de esta manera se mantiene el código de servicio mas limpio).
3) Los nuevos campos obligatorios son: nombre, apellido, correo, cedula, fecha de nacimiento y contraseña. (Se logro pasando los datos no obligatorios a que acepten null, se ajusto la entidad y por lo tanto se creo una migración). 
![image](https://github.com/user-attachments/assets/93c759e8-7bc9-4579-8928-0b8f23b4e47d)
![image](https://github.com/user-attachments/assets/08fb6235-4679-4f4b-9766-ce1bf87c704d)
![image](https://github.com/user-attachments/assets/7e174e8c-d9f2-4480-9222-90b05c34d9f9)
