### PR TITLE
feature/API-39/update-password-with-current-password

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -93,4 +93,8 @@ export class AuthService {
     await this.userService.update(user, { password });
     return true;
   }
+
+  async validatePassword(user: User, password: string): Promise<boolean> {
+    return await bcrypt.compare(password, user.password);
+  }
 }

--- a/src/auth/dto/password.dto.ts
+++ b/src/auth/dto/password.dto.ts
@@ -10,3 +10,12 @@ export class PasswordDTO {
   @MinLength(8)
   password: string;
 }
+
+export class ChangePasswordDTO extends PasswordDTO {
+  @ApiProperty({ description: 'the current password of the user' })
+  @Transform(({ value }: { value: string }) => value.trim())
+  @IsNotEmpty()
+  @MaxLength(255)
+  @MinLength(8)
+  currentPassword: string;
+}


### PR DESCRIPTION
This pull request introduces several changes to the authentication module, primarily focused on adding functionality for updating a user's password with validation of the current password. The key changes include adding a new DTO, updating the controller to handle the new functionality, and adding a method to the service for password validation.

### Changes to authentication functionality:

* [`src/auth/auth.controller.ts`](diffhunk://#diff-37d3279a8a78f12b16e161930290bf0ef16b705cb8d225e1382f364702ecaaf9R149-R176): Added a new endpoint `updateCurrentPassword` to handle password updates with current password validation. This includes the use of `ChangePasswordDTO` and appropriate guards and responses.
* [`src/auth/auth.service.ts`](diffhunk://#diff-aea62a4c305374791411369a46e8553d716a032a03bb48136176873887e3311cR96-R99): Added a new method `validatePassword` to compare the provided current password with the stored password using bcrypt.

### Changes to data transfer objects (DTOs):

* [`src/auth/dto/password.dto.ts`](diffhunk://#diff-4c55f8bd7b6726fdd9a7c04c0a6341410b8d944b15c69c109c3d83f69417a31dR13-R21): Introduced `ChangePasswordDTO` extending `PasswordDTO`, which includes an additional field for the current password with validation rules.

### Import updates:

* [`src/auth/auth.controller.ts`](diffhunk://#diff-37d3279a8a78f12b16e161930290bf0ef16b705cb8d225e1382f364702ecaaf9R2): Updated imports to include `BadRequestException` and `ChangePasswordDTO`. [[1]](diffhunk://#diff-37d3279a8a78f12b16e161930290bf0ef16b705cb8d225e1382f364702ecaaf9R2) [[2]](diffhunk://#diff-37d3279a8a78f12b16e161930290bf0ef16b705cb8d225e1382f364702ecaaf9L17-R18)