### PR TITLE
feature/add-promo-product-presentation

### DIFF
--- a/src/products/dto/product.dto.ts
+++ b/src/products/dto/product.dto.ts
@@ -12,6 +12,7 @@ import { CategoryResponseDTO } from 'src/category/dto/category.dto';
 import { ResponsePresentationDTO } from './presentation.dto';
 import { PaginationQueryDTO } from 'src/utils/dto/pagination.dto';
 import { Expose, Transform, Type } from 'class-transformer';
+import { ResponsePromoDTO } from 'src/discount/dto/promo.dto';
 
 export class AddCategoryDTO {
   @IsString()
@@ -82,6 +83,11 @@ export class ProductPresentationDTO extends BaseDTO {
   @ApiProperty({ type: ProductDTO })
   @Type(() => ProductDTO)
   product: ProductDTO;
+
+  @Expose()
+  @Type(() => ResponsePromoDTO)
+  @ApiProperty({ type: ResponsePromoDTO })
+  promo: ResponsePromoDTO;
 
   @Expose()
   @ApiProperty({ description: 'Stock quantity in all branches' })

--- a/src/products/products.service.ts
+++ b/src/products/products.service.ts
@@ -113,6 +113,15 @@ export class ProductsService {
             categories: 'product.categories',
             presentation: 'product_presentation.presentation',
           },
+          leftJoinAndSelect: {
+            promo: 'product_presentation.promo',
+          },
+        },
+        order: {
+          createdAt: 'DESC',
+          product: {
+            priority: 'ASC',
+          },
         },
         where,
         skip: (page - 1) * limit,


### PR DESCRIPTION
This pull request introduces changes to enhance the handling of promotional data (`promo`) in the product-related DTOs and services. The most important updates include adding a new `promo` field to the `ProductPresentationDTO` class, importing the corresponding DTO, and updating the query logic in the `ProductsService` to include promotional data.

### Enhancements to DTOs:

* [`src/products/dto/product.dto.ts`](diffhunk://#diff-f15b7608e25d980cbe574edaa3ee0e2fb62816b80c6ac2acfeaff58f02d8d41dR15): Added `ResponsePromoDTO` import to support the new `promo` field in the `ProductPresentationDTO` class.
* [`src/products/dto/product.dto.ts`](diffhunk://#diff-f15b7608e25d980cbe574edaa3ee0e2fb62816b80c6ac2acfeaff58f02d8d41dR87-R91): Updated `ProductPresentationDTO` to include a new `promo` field, which is exposed, typed, and documented with `ApiProperty`.

### Updates to service logic:

* [`src/products/products.service.ts`](diffhunk://#diff-96a20d758e030b096d5569de349503fa568238e0ab514be78826ed9c9f445625R116-R124): Modified the `ProductsService` to include a `leftJoinAndSelect` for `promo` in the query logic, enabling the retrieval of promotional data along with product presentations.