### PR TITLE
Feature (API-67): Reasignar sucursal a orden

### DIFF
--- a/src/order/controllers/order-delivery.controller.ts
+++ b/src/order/controllers/order-delivery.controller.ts
@@ -10,6 +10,7 @@ import {
   Query,
   Param,
   Patch,
+  Post,
 } from '@nestjs/common';
 import { OrderService } from '../order.service';
 import { AuthGuard, CustomRequest } from 'src/auth/auth.guard';
@@ -29,6 +30,11 @@ import {
 } from '../dto/order-delivery.dto';
 import { User } from 'src/user/entities/user.entity';
 import { plainToInstance } from 'class-transformer';
+import { RequestProductTransferDTO } from '../dto/order';
+import { UserRole } from 'src/user/entities/user.entity';
+import { Roles } from 'src/auth/roles.decorador';
+import { RolesGuard } from 'src/auth/roles.guard';
+import { OrderDetailDelivery } from '../entities/order_delivery.entity';
 
 @Controller('delivery')
 export class OrderDeliveryController {
@@ -148,6 +154,22 @@ export class OrderDeliveryController {
 
     return plainToInstance(OrderDeliveryDTO, updatedDelivery, {
       excludeExtraneousValues: true,
+    });
+  }
+
+  @Post('internalTransfer')
+  @UseGuards(AuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN, UserRole.BRANCH_ADMIN)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Crear deliveries de detalles desde otra sucursal' })
+  @ApiResponse({ status: HttpStatus.CREATED, type: [OrderDetailDelivery] })
+  @HttpCode(HttpStatus.CREATED)
+  async createDetailDeliveries(
+    @Body() dto: RequestProductTransferDTO,
+  ): Promise<OrderDetailDelivery[]> {
+    const created = await this.orderService.RequestProductTransferDTO(dto);
+    return plainToInstance(OrderDetailDelivery, created, {
+      excludeExtraneousValues: false,
     });
   }
 }

--- a/src/order/controllers/order.controller.ts
+++ b/src/order/controllers/order.controller.ts
@@ -39,6 +39,7 @@ import { Roles } from 'src/auth/roles.decorador';
 import { RolesGuard } from 'src/auth/roles.guard';
 import { UserValidatedGuard } from 'src/auth/guards/user-validated.guard';
 import { plainToInstance } from 'class-transformer';
+//import { RequestProductTransferDTO } from '../dto/order';
 
 @Controller('order')
 export class OrderController {
@@ -219,7 +220,7 @@ export class OrderController {
   @UseGuards(AuthGuard, RolesGuard)
   @Roles(UserRole.ADMIN, UserRole.BRANCH_ADMIN)
   @ApiBearerAuth()
-  @ApiOperation({ summary: 'Update an order by ID' })
+  @ApiOperation({ summary: 'Update an order status or reassign branch by ID' })
   @ApiResponse({
     description: 'Successful update of order',
     status: HttpStatus.OK,
@@ -229,6 +230,13 @@ export class OrderController {
     @Param('id', new ParseUUIDPipe()) id: string,
     @Body() updateOrderStatusDTO: UpdateOrderStatusDTO,
   ) {
-    return await this.orderService.update(id, updateOrderStatusDTO.status);
+    const updatedOrder = await this.orderService.update(
+      id,
+      updateOrderStatusDTO,
+    );
+    return plainToInstance(ResponseOrderDetailedDTO, updatedOrder, {
+      excludeExtraneousValues: true,
+      enableImplicitConversion: true,
+    });
   }
 }

--- a/src/order/dto/order.ts
+++ b/src/order/dto/order.ts
@@ -198,6 +198,11 @@ export class UpdateOrderStatusDTO {
   })
   @IsEnum(OrderStatus)
   status: OrderStatus;
+
+  @ApiProperty({ description: 'ID of the new branch to assign the order' })
+  @IsOptional()
+  @IsUUID()
+  branchId?: string;
 }
 
 export class UpdateOrderStatusWsDTO {
@@ -256,4 +261,23 @@ export class SalesReportDTO {
   @Expose()
   @ApiProperty({ description: 'Total of the order' })
   total: number;
+}
+
+export class RequestProductTransferDTO {
+  @ApiProperty({ description: 'ID of the order main', format: 'uuid' })
+  @IsUUID()
+  orderId: string;
+
+  @ApiProperty({ description: 'ID from branch', format: 'uuid' })
+  @IsUUID()
+  branchId: string;
+
+  @ApiProperty({
+    description: 'list of productPresentationId',
+    type: [String],
+  })
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsUUID(undefined, { each: true })
+  productPresentationIds: string[];
 }


### PR DESCRIPTION
**Tarea: Agregar branchId al actualizar una orden para que se pueda reasignar una orden a otra sucursal, Ademas crear un endpoint que reciba lista de productPresentationId y una branchId para que se haga el delivery de orderDetail en caso de que necesitemos traer productos desde otra branch a la branch encargada de la orden **

Funcionamiento (Pruebas en postman) 
*********
Patch
*********
example body:
{
  "branchId": "38ef8399-be7c-4814-bb7d-3bb7686384e4",
  "status": "ready_for_pickup"
}

Ahora podemos ademas de actualizar el estatus de una orden, podemos actualizar su sucursal

![image](https://github.com/user-attachments/assets/8c8be912-2978-41e9-ac3c-08f50dfd8506)
![image](https://github.com/user-attachments/assets/3e5371e4-1ef5-48ff-9704-2aadaad44fce)

********
Post 
********

example body:
{
  "orderId": "07e3a38f-06c7-4e35-ac47-c3648a81f0f1",
  "branchId": "38ef8399-be7c-4814-bb7d-3bb7686384e4",
  "productPresentationIds": [
    "110b91af-0a4a-4e62-9090-803c9ddc4649",
    "27f5a426-0733-4ff8-9b10-52e13d181a6d"
  ]
}

Ahora con esto podemos crear deliverys (o mejor dicho transferencias internas de productos entre sucursales)

![image](https://github.com/user-attachments/assets/4cd5c27a-7c03-4d76-a69a-42897f95a8a7)


