### PR TITLE
features/API-62/update-coordinates-with-socket

### DIFF
--- a/src/order/dto/order-delivery.dto.ts
+++ b/src/order/dto/order-delivery.dto.ts
@@ -3,7 +3,14 @@ import {
   ApiPropertyOptional,
   IntersectionType,
 } from '@nestjs/swagger';
-import { IsDateString, IsOptional, IsString, IsUUID } from 'class-validator';
+import {
+  IsDateString,
+  IsLatitude,
+  IsLongitude,
+  IsOptional,
+  IsString,
+  IsUUID,
+} from 'class-validator';
 import { PaginationQueryDTO } from 'src/utils/dto/pagination.dto';
 import { Expose, Transform, Type } from 'class-transformer';
 import { BaseUserDTO } from 'src/user/dto/user.dto';
@@ -179,4 +186,18 @@ export class UpdateDeliveryWsDTO {
   })
   @IsOptional()
   employeeId?: string;
+}
+
+export class UpdateCoordinatesWsDTO {
+  @ApiProperty({ description: 'ID of the order delivery' })
+  @IsUUID()
+  orderId: string;
+
+  @ApiProperty({ description: 'Latitude of the delivery location' })
+  @IsLatitude()
+  latitude: number;
+
+  @ApiProperty({ description: 'Longitude of the delivery location' })
+  @IsLongitude()
+  longitude: number;
 }


### PR DESCRIPTION
This pull request introduces functionality for updating delivery coordinates via WebSocket communication. Key changes include the addition of a new DTO, enhancements to the WebSocket gateway, and updates to imports to support the new feature.

### Additions to support delivery coordinates:

* **New DTO for delivery coordinates**: Added `UpdateCoordinatesWsDTO` in `src/order/dto/order-delivery.dto.ts` to handle latitude, longitude, and order ID validation. This includes new decorators like `@IsLatitude` and `@IsLongitude` for validation.

* **WebSocket gateway update**: Added a new `updateCoordinates` method in `src/order/order.gateway.ts` to handle the `updateCoordinates` WebSocket event. This method validates incoming data, checks the order's user, and emits updated coordinates to the appropriate WebSocket client.

### Supporting changes:

* **Updated imports**: Adjusted imports in `src/order/dto/order-delivery.dto.ts` and `src/order/order.gateway.ts` to include the new `UpdateCoordinatesWsDTO` and additional class-validator decorators. [[1]](diffhunk://#diff-76867dd158558fe5d6f4f2cfce13b43aec97cb4916672838615e8b9796354bf6L6-R13) [[2]](diffhunk://#diff-367470206cef7e4584139f16f82916e298c6cca8eea4b792e3b620cadba657d1L26-R29)